### PR TITLE
[WIP] Small improvements after addition of pull request merge task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,26 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+* The `pull_requests:merge` task no longer requires setting the branch name and
+  commit message provide via arguments as parameters within the task definition.
+
 ## [0.9.0] 2022-01-28
 
 ### Added
 
-* New task `pull_requests:merge[branch_name,commit_message]` to merge the PR associated with the specified branch.
+* New task `pull_requests:merge[branch_name,commit_message]` to merge the PR 
+  associated with the specified branch.
 
-  `commit_message` is optional, and can contain the original commit message with the `%s` placeholder, e.g. `pull_requests:merge[new_feature,"%s [skip ci]"]`.
+  `commit_message` is optional, and can contain the original commit message with
+  the `%s` placeholder, e.g. `pull_requests:merge[new_feature,"%s [skip ci]"]`.
 
-  Make sure to pass through `branch_name` and `commit_message` when defining your rake task:
+  Make sure to pass through `branch_name` and `commit_message` when defining
+  your rake task:
+  
   ```ruby
   RakeGithub.define_repository_tasks(
     # ...

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ require 'rake_github'
 RakeGithub.define_repository_tasks(
   namespace: :github,
   repository: 'org/repo', # required
-) do |t, args|
+) do |t|
   t.access_token = "your_github_access_token" # required
   t.deploy_keys = [
     {
@@ -40,8 +40,6 @@ RakeGithub.define_repository_tasks(
       public_key: File.read('path/to/your_deploy_key.public')
     }
   ]
-  t.branch_name = args.branch_name
-  t.commit_message = args.commit_message
 end
 ```
 
@@ -55,8 +53,6 @@ end
 | deploy_keys_provision_task_name | symbol | N        | Option to change the provision task name                   | :add                                                   | :provision                           |
 | deploy_keys_ensure_task_name    | symbol | N        | Option to change the ensure task name                      | :destroy_and_provision                                 | :ensure                              |
 | namespace                       | symbol | N        | Namespace for tasks to live in, defaults to root namespace | :rake_github                                           | N/A                                  |
-| branch_name                     | string | N        | Branch that can be merged                                  | 'cool_new_feature'                                     | N/A                                  |
-| commit_message                  | string | N        | Merge commit message                                       | 'merged PR using Rake Github'                          | "" (retains original commit message) |
 
 Exposes tasks:
 

--- a/README.md
+++ b/README.md
@@ -47,18 +47,19 @@ end
 
 | Parameter                       | Type   | Required | Description                                                | Example                                                | Default                              |
 |---------------------------------|--------|----------|------------------------------------------------------------|--------------------------------------------------------|--------------------------------------|
-| repository                      | string | Y | Repository to perform tasks upon                           | 'organisation/repository_name'                         | N/A                                  |
-| access_token                    | string | Y | Github token for authorisation                             | 'ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'            | N/A                                  |
-| deploy_keys                     | array  | N | Keys to deploy to repository                               | { title: string, public_key: string, read_only: bool } | [ ]                                  |
-| deploy_keys_namespace           | symbol | N | Namespace to contain deploy keys tasks                     | :deploy_tasks                                          | :deploy_keys                         |
-| deploy_keys_destroy_task_name   | symbol | N | Option to change the destroy task name                     | :obliterate                                            | :destroy                             |
-| deploy_keys_provision_task_name | symbol | N | Option to change the provision task name                   | :add                                                   | :provision                           |
-| deploy_keys_ensure_task_name    | symbol | N | Option to change the ensure task name                      | :destroy_and_provision                                 | :ensure                              |
-| namespace                       | symbol | N | Namespace for tasks to live in, defaults to root namespace | :rake_github                                           | N/A                                  |
-| branch_name                     | string | N | Branch that can be merged                                  | 'cool_new_feature'                                     | N/A                                  |
-| commit_message                  | string | N | Merge commit message                                       | 'merged PR using Rake Github'                          | "" (retains original commit message) |
+| repository                      | string | Y        | Repository to perform tasks upon                           | 'organisation/repository_name'                         | N/A                                  |
+| access_token                    | string | Y        | Github token for authorisation                             | 'ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'            | N/A                                  |
+| deploy_keys                     | array  | N        | Keys to deploy to repository                               | { title: string, public_key: string, read_only: bool } | [ ]                                  |
+| deploy_keys_namespace           | symbol | N        | Namespace to contain deploy keys tasks                     | :deploy_tasks                                          | :deploy_keys                         |
+| deploy_keys_destroy_task_name   | symbol | N        | Option to change the destroy task name                     | :obliterate                                            | :destroy                             |
+| deploy_keys_provision_task_name | symbol | N        | Option to change the provision task name                   | :add                                                   | :provision                           |
+| deploy_keys_ensure_task_name    | symbol | N        | Option to change the ensure task name                      | :destroy_and_provision                                 | :ensure                              |
+| namespace                       | symbol | N        | Namespace for tasks to live in, defaults to root namespace | :rake_github                                           | N/A                                  |
+| branch_name                     | string | N        | Branch that can be merged                                  | 'cool_new_feature'                                     | N/A                                  |
+| commit_message                  | string | N        | Merge commit message                                       | 'merged PR using Rake Github'                          | "" (retains original commit message) |
 
 Exposes tasks:
+
 ```shell
 $ rake -T
 
@@ -69,18 +70,23 @@ rake github:pull_requests:merge[branch_name,commit_message]
 ```
 
 #### deploy_keys:provision
+
 Provisions deploy keys to the specified repository.
 
 #### deploy_keys:destroy
+
 Destroys deploy keys from the specified repository.
 
 #### deploy_keys:ensure
+
 Destroys and then provisions deploy keys on the specified repository.
 
 #### pull_requests:merge[branch_name,commit_message]
+
 Merges the PR associated with the `branch_name`. Branch name is required.
 
-`commit_message` is optional, and can contain the original commit message with the `%s` placeholder, e.g. `pull_requests:merge[new_feature,"%s [skip ci]"]`.
+`commit_message` is optional, and can contain the original commit message with
+the `%s` placeholder, e.g. `pull_requests:merge[new_feature,"%s [skip ci]"]`.
 
 ### define_release_task
 
@@ -121,13 +127,12 @@ openssl aes-256-cbc \
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at 
-https://github.com/infrablocks/rake_github. This project is intended to be a 
-safe, welcoming space for collaboration, and contributors are expected to 
-adhere to the [Contributor Covenant](http://contributor-covenant.org) code of 
-conduct.
+Bug reports and pull requests are welcome on GitHub at
+https://github.com/infrablocks/rake_github. This project is intended to be a
+safe, welcoming space for collaboration, and contributors are expected to adhere
+to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.
 
 ## License
 
-The gem is available as open source under the terms of the 
+The gem is available as open source under the terms of the
 [MIT License](http://opensource.org/licenses/MIT).

--- a/Rakefile
+++ b/Rakefile
@@ -146,7 +146,7 @@ end
 RakeGithub.define_repository_tasks(
   namespace: :github,
   repository: 'infrablocks/rake_github'
-) do |t, args|
+) do |t|
   github_config =
     YAML.load_file('config/secrets/github/config.yaml')
 
@@ -157,8 +157,6 @@ RakeGithub.define_repository_tasks(
       public_key: File.read('config/secrets/ci/ssh.public')
     }
   ]
-  t.branch_name = args.branch_name
-  t.commit_message = args.commit_message
 end
 
 namespace :pipeline do

--- a/lib/rake_github.rb
+++ b/lib/rake_github.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'rake_github/exceptions'
 require 'rake_github/version'
 require 'rake_github/tasks'
 require 'rake_github/task_sets'

--- a/lib/rake_github/exceptions.rb
+++ b/lib/rake_github/exceptions.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+require_relative 'exceptions/no_pull_request_error'

--- a/lib/rake_github/exceptions.rb
+++ b/lib/rake_github/exceptions.rb
@@ -1,3 +1,4 @@
 # frozen_string_literal: true
 
-require_relative 'exceptions/no_pull_request_error'
+require_relative 'exceptions/no_pull_request'
+require_relative 'exceptions/required_argument_unset'

--- a/lib/rake_github/exceptions/no_pull_request.rb
+++ b/lib/rake_github/exceptions/no_pull_request.rb
@@ -2,13 +2,13 @@
 
 module RakeGithub
   module Exceptions
-    class NoPullRequestError < StandardError
+    class NoPullRequest < StandardError
       attr_reader :branch_name
 
       def initialize(branch_name)
         @branch_name = branch_name
 
-        super('No pull request associated with branch %s' % branch_name)
+        super(format('No pull request associated with branch %s', branch_name))
       end
     end
   end

--- a/lib/rake_github/exceptions/no_pull_request_error.rb
+++ b/lib/rake_github/exceptions/no_pull_request_error.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module RakeGithub
+  module Exceptions
+    class NoPullRequestError < StandardError
+      attr_reader :branch_name
+
+      def initialize(branch_name)
+        @branch_name = branch_name
+
+        super('No pull request associated with branch %s' % branch_name)
+      end
+    end
+  end
+end

--- a/lib/rake_github/exceptions/required_argument_unset.rb
+++ b/lib/rake_github/exceptions/required_argument_unset.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module RakeGithub
+  module Exceptions
+    class RequiredArgumentUnset < ::StandardError
+    end
+  end
+end

--- a/lib/rake_github/task_sets/repository.rb
+++ b/lib/rake_github/task_sets/repository.rb
@@ -39,6 +39,7 @@ module RakeGithub
              ts.deploy_keys_destroy_task_name
            }
       task Tasks::PullRequests::Merge,
+           # TODO: should this be here?
            argument_names: %i[branch_name commit_message],
            branch_name: RakeFactory::DynamicValue.new { |ts|
              ts.branch_name

--- a/lib/rake_github/task_sets/repository.rb
+++ b/lib/rake_github/task_sets/repository.rb
@@ -17,8 +17,6 @@ module RakeGithub
       parameter :deploy_keys_destroy_task_name, default: :destroy
       parameter :deploy_keys_provision_task_name, default: :provision
       parameter :deploy_keys_ensure_task_name, default: :ensure
-      parameter :branch_name
-      parameter :commit_message, default: ''
 
       task Tasks::DeployKeys::Provision,
            name: RakeFactory::DynamicValue.new { |ts|
@@ -38,15 +36,7 @@ module RakeGithub
            destroy_task_name: RakeFactory::DynamicValue.new { |ts|
              ts.deploy_keys_destroy_task_name
            }
-      task Tasks::PullRequests::Merge,
-           # TODO: should this be here?
-           argument_names: %i[branch_name commit_message],
-           branch_name: RakeFactory::DynamicValue.new { |ts|
-             ts.branch_name
-           },
-           commit_message: RakeFactory::DynamicValue.new { |ts|
-             ts.commit_message
-           }
+      task Tasks::PullRequests::Merge
 
       def define_on(application)
         around_define(application) do

--- a/lib/rake_github/tasks/pull_requests/merge.rb
+++ b/lib/rake_github/tasks/pull_requests/merge.rb
@@ -41,16 +41,3 @@ module RakeGithub
     end
   end
 end
-
-class NoPullRequestError < StandardError
-  attr_reader :branch_name
-
-  def initialize(branch_name)
-    super()
-    @branch_name = branch_name
-  end
-
-  def message
-    format('No pull request associated with branch %s', branch_name)
-  end
-end

--- a/lib/rake_github/tasks/pull_requests/merge.rb
+++ b/lib/rake_github/tasks/pull_requests/merge.rb
@@ -3,6 +3,8 @@
 require 'rake_factory'
 require 'octokit'
 
+require_relative '../../exceptions/no_pull_request_error'
+
 module RakeGithub
   module Tasks
     module PullRequests
@@ -25,7 +27,9 @@ module RakeGithub
           open_prs = client.pull_requests(t.repository)
           current_pr = open_prs.find { |pr| pr[:head][:ref] == t.branch_name }
 
-          raise NoPullRequestError, t.branch_name if current_pr.nil?
+          # rubocop:disable Style/RaiseArgs
+          raise Exceptions::NoPullRequestError.new(t.branch_name) if current_pr.nil?
+          # rubocop:enable Style/RaiseArgs
 
           client.merge_pull_request(
             t.repository,

--- a/spec/rake_github/tasks/pull_requests/merge_spec.rb
+++ b/spec/rake_github/tasks/pull_requests/merge_spec.rb
@@ -38,11 +38,8 @@ describe RakeGithub::Tasks::PullRequests::Merge do
   end
 
   it 'fails if no repository is provided' do
-    define_task(
-      argument_names: [:branch_name]
-    ) do |t, args|
+    define_task do |t|
       t.access_token = 'some-token'
-      t.branch_name = args.branch_name
     end
 
     expect do
@@ -51,11 +48,8 @@ describe RakeGithub::Tasks::PullRequests::Merge do
   end
 
   it 'fails if no access token is provided' do
-    define_task(
-      argument_names: [:branch_name]
-    ) do |t, args|
+    define_task do |t|
       t.repository = 'org/repo'
-      t.branch_name = args.branch_name
     end
 
     expect do
@@ -64,17 +58,14 @@ describe RakeGithub::Tasks::PullRequests::Merge do
   end
 
   it 'fails if no branch_name is provided' do
-    define_task(
-      argument_names: [:branch_name]
-    ) do |t, args|
+    define_task do |t|
       t.repository = 'org/repo'
       t.access_token = 'some-token'
-      t.branch_name = args.branch_name
     end
 
     expect do
       Rake::Task['pull_requests:merge'].invoke
-    end.to raise_error(RakeFactory::RequiredParameterUnset)
+    end.to raise_error(RakeGithub::Exceptions::RequiredArgumentUnset)
   end
 
   it 'uses provided access token when communicating with Github' do
@@ -93,12 +84,9 @@ describe RakeGithub::Tasks::PullRequests::Merge do
       client, repository, 1, 'add feature'
     )
 
-    define_task(
-      argument_names: [:branch_name]
-    ) do |t, args|
+    define_task do |t|
       t.repository = repository
       t.access_token = access_token
-      t.branch_name = args.branch_name
     end
 
     Rake::Task['pull_requests:merge'].invoke('mergeable_branch')
@@ -124,12 +112,9 @@ describe RakeGithub::Tasks::PullRequests::Merge do
       client, repository, 1, 'add feature'
     )
 
-    define_task(
-      argument_names: [:branch_name]
-    ) do |t, args|
+    define_task do |t, _args|
       t.repository = repository
       t.access_token = access_token
-      t.branch_name = args.branch_name
     end
 
     Rake::Task['pull_requests:merge'].invoke('mergeable_branch')
@@ -156,16 +141,12 @@ describe RakeGithub::Tasks::PullRequests::Merge do
       client, repository, 1, 'merge PR #1'
     )
 
-    define_task(
-      argument_names: [:branch_name]
-    ) do |t, args|
+    define_task do |t|
       t.repository = repository
       t.access_token = access_token
-      t.branch_name = args.branch_name
-      t.commit_message = commit_message
     end
 
-    Rake::Task['pull_requests:merge'].invoke('mergeable_branch')
+    Rake::Task['pull_requests:merge'].invoke('mergeable_branch', commit_message)
 
     expect(client)
       .to(have_received(:merge_pull_request)
@@ -189,16 +170,12 @@ describe RakeGithub::Tasks::PullRequests::Merge do
       client, repository, 1, 'add feature [skip ci]'
     )
 
-    define_task(
-      argument_names: [:branch_name]
-    ) do |t, args|
+    define_task do |t|
       t.repository = repository
       t.access_token = access_token
-      t.branch_name = args.branch_name
-      t.commit_message = commit_message
     end
 
-    Rake::Task['pull_requests:merge'].invoke('mergeable_branch')
+    Rake::Task['pull_requests:merge'].invoke('mergeable_branch', commit_message)
 
     expect(client)
       .to(have_received(:merge_pull_request)
@@ -216,18 +193,15 @@ describe RakeGithub::Tasks::PullRequests::Merge do
       ]
     )
 
-    define_task(
-      argument_names: [:branch_name]
-    ) do |t, args|
+    define_task do |t, _args|
       t.repository = repository
       t.access_token = access_token
-      t.branch_name = args.branch_name
     end
 
     expect do
       Rake::Task['pull_requests:merge'].invoke('branch_with_no_PR')
     end.to(raise_error(
-             NoPullRequestError,
+             RakeGithub::Exceptions::NoPullRequest,
              'No pull request associated with branch branch_with_no_PR'
            ))
   end


### PR DESCRIPTION
Specifically:
* Move top level exception class inside `RakeGithub` module
* Add namespace / task name configuration parameters to task set

Additional points for discussion:
* Should `branch_name` and `commit_message` be default arguments of the `Merge` task?
* If so, how do we also allow those parameters to be overridden in task configuration blocks? This will require changes to `rake_factory`...