### PR TITLE
Fix CI base image and add libsodium

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ orbs:
   slack: circleci/slack@4.13.2
 
 base_container: &base_container
-  image: buildpack-deps:buster
+  image: buildpack-deps:bookworm
 
 build_container: &build_container
   resource_class: arm.medium
@@ -69,15 +69,16 @@ commands:
   configure_build_tools:
     steps:
       - run: ./scripts/ci/common/install-slack-deps.sh
+      - run: ./scripts/ci/common/install-libsodium.sh
       - restore_cache:
           keys:
-            - asdf-dependencies-{{ arch }}-v2-{{ checksum ".tool-versions" }}
-            - asdf-dependencies-{{ arch }}-v2-
+            - asdf-dependencies-{{ arch }}-v3-{{ checksum ".tool-versions" }}
+            - asdf-dependencies-{{ arch }}-v3-
       - run: ./scripts/ci/common/install-asdf.sh
       - run: ./scripts/ci/common/configure-asdf.sh
       - run: ./scripts/ci/common/install-asdf-dependencies.sh
       - save_cache:
-          key: asdf-dependencies-{{ arch }}-v2-{{ checksum ".tool-versions" }}
+          key: asdf-dependencies-{{ arch }}-v3-{{ checksum ".tool-versions" }}
           paths:
             - ~/.asdf
 

--- a/scripts/ci/common/install-libsodium.sh
+++ b/scripts/ci/common/install-libsodium.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+[ -n "$DEBUG" ] && set -x
+set -e
+set -o pipefail
+
+apt-get update
+apt-get install -y --no-install-recommends libsodium-dev


### PR DESCRIPTION
## Why

Every CircleCI job currently fails at `install-slack-deps.sh`: Debian buster was archived off `deb.debian.org`, so `apt-get update` on `buildpack-deps:buster` now 404s.

## What

- Bump the base image to `buildpack-deps:bookworm`.
- Bump the asdf cache key (`v2` → `v3`) so Ruby is recompiled against bookworm's OpenSSL 3 rather than restored from a buster-built cache linking the removed OpenSSL 1.1.
- Install `libsodium-dev` in all jobs, ahead of the upcoming `secrets` task groups which need `rbnacl` (libsodium sealed-box encryption of GitHub secret values).

## Verification

Verified locally in docker on arm64 (matching the `arm.medium` resource class): apt on bookworm resolves and installs `libsodium-dev`, providing `libsodium.so`. The branch-filtered workflow only runs on `main`/`dependabot*`, so the real verification is the pipeline run after merge — this PR should be merged and observed green (through prerelease) before the task-groups PR lands.